### PR TITLE
fix temurin version, arch and OSname display bug

### DIFF
--- a/src/components/Temurin/LatestTemurin/index.tsx
+++ b/src/components/Temurin/LatestTemurin/index.tsx
@@ -69,20 +69,19 @@ const LatestTemurin = (props): JSX.Element => {
         {binary ? (
           <Trans
             i18nKey="Download Temurin for"
-            defaults="Download Temurin {{ defaultVersion }} for {{ userOSName }} {{ arch }}"
-            components={{
-              defaultVersion: defaultVersion,
-              userOSName: userOSName,
-              arch: arch
+            defaults="Download Temurin {{defaultVersion}} for {{userOSName}} {{arch}}"
+            values={{
+              defaultVersion,
+              userOSName,
+              arch,
             }}
-          />) : (
-          <Trans 
-            i18nKey="home.download.temurin.short" 
+          />
+        ) : (
+          <Trans
+            i18nKey="home.download.temurin.short"
             defaults="Download Temurin {{ defaultVersion }}"
-            components={{
-              defaultVersion: defaultVersion
-            }}
-             />
+            value={{ defaultVersion }}
+          />
         )}
       </p>
       <div className="mt-10 flex items-center sm:flex-row flex-col-reverse justify-center gap-6">


### PR DESCRIPTION
# Description of change
  Seems there was breaking change in the [`Trans`](https://react.i18next.com/latest/trans-component) component. That's how best I can think of it
closes https://github.com/adoptium/adoptium.net-redesign/issues/709
  
```
<Trans
  i18nKey="myKey" // optional -> fallbacks to defaults if not provided
  defaults="hello <italic>beautiful</italic> <bold>{{what}}</bold>" // optional defaultValue
  values={{ what: 'world'}}
  components={{ italic: <i />, bold: <strong /> }}
/>
```
 <!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)

## Screeenshots
<img width="925" alt="Screenshot 2025-01-27 at 08 50 02" src="https://github.com/user-attachments/assets/9a283393-27e3-4baa-b7a2-7a2410c3c8af" />
