### PR TITLE
fix: Documentation authors images exceeding page width on mobile

### DIFF
--- a/src/components/Asciidoc/AuthorList/__tests__/__snapshots__/author-list.test.tsx.snap
+++ b/src/components/Asciidoc/AuthorList/__tests__/__snapshots__/author-list.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`AuthorsList component > renders correctly 1`] = `
       Text
     </div>
     <div
-      class="justify-start items-center space-x-[-12px] inline-flex"
+      class="flex flex-wrap justify-start items-center space-x-[-12px]"
     >
       <a
         aria-label="test-author"

--- a/src/components/Asciidoc/AuthorList/index.tsx
+++ b/src/components/Asciidoc/AuthorList/index.tsx
@@ -16,7 +16,7 @@ const AuthorList = ({ authors }: Props): JSX.Element => {
             defaults="Documentation Authors"
           />
         </div>
-        <div className="justify-start items-center space-x-[-12px] inline-flex">
+        <div className="flex flex-wrap justify-start items-center space-x-[-12px]">
           {authors.map(
             (author, i): JSX.Element => (
               <Author username={author} key={author} size="48" />

--- a/src/templates/__tests__/__snapshots__/asciidoc.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/asciidoc.test.tsx.snap
@@ -70,9 +70,7 @@ exports[`Asciidoc pages > renders correctly - installation slug 1`] = `
         </div>
         <div
           class="self-stretch text-center text-lightgrey text-[20px] font-normal leading-[140%] undefined"
-        >
-          fooBar
-        </div>
+        />
       </div>
     </div>
   </div>
@@ -541,7 +539,7 @@ exports[`Asciidoc pages > renders correctly - installation slug 1`] = `
             Text
           </div>
           <div
-            class="justify-start items-center space-x-[-12px] inline-flex"
+            class="flex flex-wrap justify-start items-center space-x-[-12px]"
           >
             <a
               aria-label="author1"
@@ -1076,9 +1074,7 @@ exports[`Asciidoc pages > renders correctly 1`] = `
         </div>
         <div
           class="self-stretch text-center text-lightgrey text-[20px] font-normal leading-[140%] undefined"
-        >
-          fooBar
-        </div>
+        />
       </div>
     </div>
   </div>
@@ -1321,7 +1317,7 @@ exports[`Asciidoc pages > renders correctly 1`] = `
             Text
           </div>
           <div
-            class="justify-start items-center space-x-[-12px] inline-flex"
+            class="flex flex-wrap justify-start items-center space-x-[-12px]"
           >
             <a
               aria-label="author1"

--- a/src/templates/asciidocTemplate.tsx
+++ b/src/templates/asciidocTemplate.tsx
@@ -43,7 +43,7 @@ const AsciidocTemplate = ({ data, pageContext }) => {
       <PageHeader
         title={document.title}
         subtitle="Documentation"
-        description="fooBar"
+        description=""
       />
       <section className="mx-auto max-w-4xl w-full p-6 lg:px-0 flex flex-col items-center justify-center">
         <div className="asciidoc-container w-full" id="asciidoc-container">


### PR DESCRIPTION
# Description of change

fixes: #739 

<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
