### PR TITLE
[issue-765] Fix rendering tab based on url

### DIFF
--- a/src/components/Temurin/Tabs/index.tsx
+++ b/src/components/Temurin/Tabs/index.tsx
@@ -47,7 +47,8 @@ const Tabs = ({ updaterAction, Table, openModalWithChecksum }) => {
   const [arch, updateArch] = useState("any")
   const [version, udateVersion] = useState("any")
 
-  const [active, setActive] = useState(data.mostRecentLts.version)
+  const [activeVersionSelectorTab, setActiveVersionSelectorTab] = useState(data.mostRecentLts.version)
+
   const [releases, setReleases] = useState(null)
 
   /**
@@ -94,12 +95,9 @@ const Tabs = ({ updaterAction, Table, openModalWithChecksum }) => {
 
         if (versionParamStr.toLowerCase() === "latest") {
           // get the latest version of the list
-          defaultSelectedVersion = LTSVersions.sort(
-            (a, b) => b.node.version - a.node.version,
-          )[0].node.version
-        } else if (
-          LTSVersions.findIndex(version => version.node.version === versionParamNum) >= 0
-        ) {
+          defaultSelectedVersion = LTSVersions
+            .sort((a, b) => b.node.version - a.node.version,)[0].node.version
+        } else if (LTSVersions.findIndex(version => version.node.version === versionParamNum) >= 0) {
           defaultSelectedVersion = versionParamNum
         }
       }
@@ -119,6 +117,7 @@ const Tabs = ({ updaterAction, Table, openModalWithChecksum }) => {
       osUpdater(defaultSelectedOS);
       archUpdater(defaultSelectedArch);
       versionUpdater(defaultSelectedVersion);
+      setActiveVersionSelectorTab(defaultSelectedVersion);
 
       // OK we can loaded elements
       setReady(true)
@@ -157,13 +156,13 @@ const Tabs = ({ updaterAction, Table, openModalWithChecksum }) => {
       <section className="py-8 md:pt-16 px-6 w-full">
         <div className="w-full flex flex-col items-start justify-start sm:items-center sm:justify-center">
           <VersionSelector
-            active={active}
-            setActive={setActive}
+            activeVersionTab={activeVersionSelectorTab}
+            setActiveVersionTab={setActiveVersionSelectorTab}
             versions={LTSVersions}
             updateVersion={udateVersion}
             defaultVersion={data.mostRecentLts.version}
           />
-          {active === 1 ? (
+          {activeVersionSelectorTab === 1 ? (
             <ReleaseSelector
               versions={data.allVersions}
               updateVersion={versionUpdater}

--- a/src/components/Temurin/Tabs/index.tsx
+++ b/src/components/Temurin/Tabs/index.tsx
@@ -88,6 +88,7 @@ const Tabs = ({ updaterAction, Table, openModalWithChecksum }) => {
 
       // init the default selected Version, if any from the param 'version' or from 'variant'
       let defaultSelectedVersion = data.mostRecentLts.version
+      let defaultActiveVersionSelectorTab = data.mostRecentLts.version
       const versionParam = queryStringParams.version
       if (versionParam) {
         let versionParamStr = versionParam.toString()
@@ -95,10 +96,16 @@ const Tabs = ({ updaterAction, Table, openModalWithChecksum }) => {
 
         if (versionParamStr.toLowerCase() === "latest") {
           // get the latest version of the list
-          defaultSelectedVersion = LTSVersions
-            .sort((a, b) => b.node.version - a.node.version,)[0].node.version
+          defaultSelectedVersion = LTSVersions.sort((a, b) => b.node.version - a.node.version,)[0].node.version;
+          defaultActiveVersionSelectorTab = defaultSelectedVersion;
         } else if (LTSVersions.findIndex(version => version.node.version === versionParamNum) >= 0) {
-          defaultSelectedVersion = versionParamNum
+          // it is a valid LTS version
+          defaultSelectedVersion = versionParamNum;
+          defaultActiveVersionSelectorTab = versionParamNum;
+        } else {
+          // it is another valid version
+          defaultSelectedVersion = versionParamNum;
+          defaultActiveVersionSelectorTab = 1;
         }
       }
 
@@ -117,7 +124,7 @@ const Tabs = ({ updaterAction, Table, openModalWithChecksum }) => {
       osUpdater(defaultSelectedOS);
       archUpdater(defaultSelectedArch);
       versionUpdater(defaultSelectedVersion);
-      setActiveVersionSelectorTab(defaultSelectedVersion);
+      setActiveVersionSelectorTab(defaultActiveVersionSelectorTab);
 
       // OK we can loaded elements
       setReady(true)

--- a/src/components/Temurin/VersionSelector/index.tsx
+++ b/src/components/Temurin/VersionSelector/index.tsx
@@ -3,21 +3,21 @@ import React, { useCallback } from "react"
 import { setURLParam } from "../../../util/setURLParam"
 
 const VersionSelector = ({
-  active,
-  setActive,
+  activeVersionTab,
+  setActiveVersionTab,
   versions,
   updateVersion,
   defaultVersion,
 }) => {
-  const setVersion = useCallback(version => {
-    if (version === 1) {
+  const setActiveTabVersion = useCallback(newActiveVersionTab => {
+    if (newActiveVersionTab === 1) {
       setURLParam("version", defaultVersion)
       updateVersion(defaultVersion)
     } else {
-      setURLParam("version", version)
-      updateVersion(version)
+      setURLParam("version", newActiveVersionTab)
+      updateVersion(newActiveVersionTab)
     }
-    setActive(version)
+    setActiveVersionTab(newActiveVersionTab)
   }, [])
 
   return (
@@ -25,10 +25,10 @@ const VersionSelector = ({
       <div className="overflow-auto relative min-w-full w-full ">
         <span className="h-[1px] w-full bg-[#3E3355] inline-block absolute bottom-0 z-[-1]"></span>
         <div className="flex space-x-10 whitespace-nowrap   lg:justify-center py-3">
-          <button onClick={() => setVersion(1)}>
+          <button onClick={() => setActiveTabVersion(1)}>
             <span
               className={` py-3  w-full text-base font-normal leading-6 
-                outline-none cursor-pointer transition-all duration-200 ease-in-out ${active === 1 ? "border-primary  border-b-[2px] text-white" : "text-[#8a809e] border-transparent  border-b"}`}
+                outline-none cursor-pointer transition-all duration-200 ease-in-out ${activeVersionTab === 1 ? "border-primary  border-b-[2px] text-white" : "text-[#8a809e] border-transparent  border-b"}`}
             >
               All Versions
             </span>
@@ -36,11 +36,11 @@ const VersionSelector = ({
           {versions.map((version, index) => (
             <button
               key={index}
-              onClick={() => setVersion(version.node.version)}
+              onClick={() => setActiveTabVersion(version.node.version)}
             >
               <span
                 className={` py-3  w-full text-base font-normal leading-6
-                    outline-none cursor-pointer transition-all duration-200 ease-in-out ${active === version.node.version ? "border-primary  border-b-[2px] text-white" : "text-[#8a809e] border-transparent  border-b"}`}
+                    outline-none cursor-pointer transition-all duration-200 ease-in-out ${activeVersionTab === version.node.version ? "border-primary  border-b-[2px] text-white" : "text-[#8a809e] border-transparent  border-b"}`}
               >
                 JDK {version.node.label}
               </span>


### PR DESCRIPTION
# Description of change
This PR is to fix the problem Tab update depending of version  in url params.
I have renamed the "active" useState to "activeVersionSelectorTab" for a better understanding.

## Checklist
- [X] `npm test` passes
