### PR TITLE
Improve marketplace design (bgcolor white / tabs)

### DIFF
--- a/src/components/Marketplace/AllReleaseCard/index.tsx
+++ b/src/components/Marketplace/AllReleaseCard/index.tsx
@@ -30,10 +30,10 @@ const AllReleaseCard = ({ results }) => {
               </h3>
             </div>
             <div className="lg:flex items-center gap-20">
-              <p className="text-base font-bold leading-[150%] mb-0  hidden lg:block">
+              <p className="text-base font-bold leading-[150%] mb-0 hidden lg:block w-[140px]">
                 {capitalize(release.binary.distribution)}
               </p>
-              <span className="fill-primary hidden md:block">
+              <span className="fill-primary hidden md:block" style={{ backgroundColor: "#fff", padding: "10px", borderRadius: "6%" }}>
                 <img
                   className="w-[100px] mb-0"
                   alt={`${release.binary.distribution} logo`}

--- a/src/components/Marketplace/DownloadTable/index.tsx
+++ b/src/components/Marketplace/DownloadTable/index.tsx
@@ -203,11 +203,11 @@ const DownloadTable = () => {
         selectedVendorIdentifiers={selectedVendorIdentifiers}
         setSelectedVendorIdentifiers={updateSelectedVendorIdentifiers}
       />
-      <div className="hidden md:flex items-center gap-20 border-t border-[#3E3355] pt-5 mb-5 mt-12">
+      <div className="hidden md:flex items-center gap-20 border-t border-[#3E3355] pt-5 mb-5 mt-12 pl-10">
         <p className="text-grey text-[16px] leading-[24px] mb-0">
           <Trans>Build Version</Trans>
         </p>
-        <p className="text-grey text-[16px] leading-[24px] mb-0">
+        <p className="text-grey text-[16px] leading-[24px] mb-0 w-[140px]">
           <Trans>Distribution</Trans>
         </p>
         <p className="text-grey text-[16px] leading-[24px] mb-0">

--- a/src/pages/__tests__/__snapshots__/marketplace.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/marketplace.test.tsx.snap
@@ -326,7 +326,7 @@ exports[`Marketplace page > renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="hidden md:flex items-center gap-20 border-t border-[#3E3355] pt-5 mb-5 mt-12"
+      class="hidden md:flex items-center gap-20 border-t border-[#3E3355] pt-5 mb-5 mt-12 pl-10"
     >
       <p
         class="text-grey text-[16px] leading-[24px] mb-0"
@@ -334,7 +334,7 @@ exports[`Marketplace page > renders correctly 1`] = `
         Text
       </p>
       <p
-        class="text-grey text-[16px] leading-[24px] mb-0"
+        class="text-grey text-[16px] leading-[24px] mb-0 w-[140px]"
       >
         Text
       </p>


### PR DESCRIPTION
# Description of change
I have added a white background color to logo, and add some spacesto improve the presentation.

![image](https://github.com/user-attachments/assets/0c2a9e4c-7cd1-48b9-bc38-8b0462c8f8a3)



## Checklist
- [X] `npm test` passes
