### PR TITLE
[issue-969] Add news sub buttons

### DIFF
--- a/src/components/News/NewsCardList/index.tsx
+++ b/src/components/News/NewsCardList/index.tsx
@@ -36,9 +36,17 @@ const NewsCardList = ({
         baseUrl={baseUrl}
       />
       <div className="flex items-center gap-5">
-        <Link to="https://newsroom.eclipse.org/eclipse/community-news" className="flex items-center gap-3">View all</Link>
-        |
-        <Link to="https://newsroom.eclipse.org/node/add/news" className="flex items-center gap-3">Submit news</Link>
+        <a 
+          href="https://newsroom.eclipse.org/eclipse/community-news" 
+          target="_blank" 
+          rel="noopener noreferrer" 
+          className="flex items-center gap-3">View all</a>
+        | 
+        <a 
+          href="https://newsroom.eclipse.org/node/add/news" 
+          target="_blank" 
+          rel="noopener noreferrer" 
+          className="flex items-center gap-3">Submit news</a>
       </div>
     </div>
   );

--- a/src/components/News/NewsCardList/index.tsx
+++ b/src/components/News/NewsCardList/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import EventCard from "../../Events/EventCard";
-import Pagination from "../Pagination"; // adjust the import path as needed
+import Pagination from "../Pagination";
+import { Link } from "../../../components/Link";
 
 const NewsCardList = ({
   posts,
@@ -26,7 +27,6 @@ const NewsCardList = ({
           <EventCard key={index} post={post} />
         ))}
       </div>
-
       <Pagination
         previousPageNumber={previousPageNumber}
         previousPageLink={previousPageLink}
@@ -35,6 +35,11 @@ const NewsCardList = ({
         totalPages={totalPages}
         baseUrl={baseUrl}
       />
+      <div className="flex items-center gap-5">
+        <Link to="https://newsroom.eclipse.org/eclipse/community-news" className="flex items-center gap-3">View all</Link>
+        |
+        <Link to="https://newsroom.eclipse.org/node/add/news" className="flex items-center gap-3">Submit news</Link>
+      </div>
     </div>
   );
 };

--- a/src/pages/__tests__/__snapshots__/news.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/news.test.tsx.snap
@@ -152,14 +152,18 @@ exports[`News page > renders correctly 1`] = `
     >
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+        href="https://newsroom.eclipse.org/eclipse/community-news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         View all
       </a>
       |
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/node/add/news"
+        href="https://newsroom.eclipse.org/node/add/news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Submit news
       </a>

--- a/src/pages/__tests__/__snapshots__/news.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/news.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`News page > renders correctly 1`] = `
         <div
           class="self-stretch text-center text-lightgrey text-[20px] font-normal leading-[140%] mx-auto max-w-[860px] px-2 w-full"
         >
-          Eclipse Temurin offers high-performance, cross-platform, open-source Java runtime binaries that are enterprise-ready and Java SE TCK-tested for general use in the Java ecosystem.
+          Follow the latest updates from the Eclipse Adoptium Project
         </div>
       </div>
     </div>
@@ -146,6 +146,23 @@ exports[`News page > renders correctly 1`] = `
           </a>
         </div>
       </div>
+    </div>
+    <div
+      class="flex items-center gap-5"
+    >
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+      >
+        View all
+      </a>
+      |
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/node/add/news"
+      >
+        Submit news
+      </a>
     </div>
   </div>
 </main>

--- a/src/pages/news.tsx
+++ b/src/pages/news.tsx
@@ -28,7 +28,7 @@ const NewsIndex = ({ data }) => {
       <PageHeader
         subtitle="News"
         title="News & Updates"
-        description="Eclipse Temurin offers high-performance, cross-platform, open-source Java runtime binaries that are enterprise-ready and Java SE TCK-tested for general use in the Java ecosystem."
+        description="Follow the latest updates from the Eclipse Adoptium Project"
         className="mx-auto max-w-[860px] px-2 w-full"
       />
       <NewsCardList 

--- a/src/templates/__tests__/__snapshots__/authorPage.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/authorPage.test.tsx.snap
@@ -240,6 +240,23 @@ exports[`AuthorPage pages > renders correctly - with next and previous paginatio
         </span>
       </a>
     </div>
+    <div
+      class="flex items-center gap-5"
+    >
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+      >
+        View all
+      </a>
+      |
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/node/add/news"
+      >
+        Submit news
+      </a>
+    </div>
   </div>
 </main>
 `;
@@ -454,6 +471,23 @@ exports[`AuthorPage pages > renders correctly - with next pagination 1`] = `
             />
           </svg>
         </span>
+      </a>
+    </div>
+    <div
+      class="flex items-center gap-5"
+    >
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+      >
+        View all
+      </a>
+      |
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/node/add/news"
+      >
+        Submit news
       </a>
     </div>
   </div>
@@ -700,6 +734,23 @@ exports[`AuthorPage pages > renders correctly - with previous pagination 1`] = `
         </span>
       </a>
     </div>
+    <div
+      class="flex items-center gap-5"
+    >
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+      >
+        View all
+      </a>
+      |
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/node/add/news"
+      >
+        Submit news
+      </a>
+    </div>
   </div>
 </main>
 `;
@@ -914,6 +965,23 @@ exports[`AuthorPage pages > renders correctly 1`] = `
             />
           </svg>
         </span>
+      </a>
+    </div>
+    <div
+      class="flex items-center gap-5"
+    >
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+      >
+        View all
+      </a>
+      |
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/node/add/news"
+      >
+        Submit news
       </a>
     </div>
   </div>

--- a/src/templates/__tests__/__snapshots__/authorPage.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/authorPage.test.tsx.snap
@@ -245,14 +245,18 @@ exports[`AuthorPage pages > renders correctly - with next and previous paginatio
     >
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+        href="https://newsroom.eclipse.org/eclipse/community-news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         View all
       </a>
       |
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/node/add/news"
+        href="https://newsroom.eclipse.org/node/add/news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Submit news
       </a>
@@ -478,14 +482,18 @@ exports[`AuthorPage pages > renders correctly - with next pagination 1`] = `
     >
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+        href="https://newsroom.eclipse.org/eclipse/community-news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         View all
       </a>
       |
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/node/add/news"
+        href="https://newsroom.eclipse.org/node/add/news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Submit news
       </a>
@@ -739,14 +747,18 @@ exports[`AuthorPage pages > renders correctly - with previous pagination 1`] = `
     >
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+        href="https://newsroom.eclipse.org/eclipse/community-news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         View all
       </a>
       |
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/node/add/news"
+        href="https://newsroom.eclipse.org/node/add/news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Submit news
       </a>
@@ -972,14 +984,18 @@ exports[`AuthorPage pages > renders correctly 1`] = `
     >
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+        href="https://newsroom.eclipse.org/eclipse/community-news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         View all
       </a>
       |
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/node/add/news"
+        href="https://newsroom.eclipse.org/node/add/news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Submit news
       </a>

--- a/src/templates/__tests__/__snapshots__/newsPage.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/newsPage.test.tsx.snap
@@ -243,14 +243,18 @@ exports[`News Template page > renders correctly 1`] = `
     >
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+        href="https://newsroom.eclipse.org/eclipse/community-news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         View all
       </a>
       |
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/node/add/news"
+        href="https://newsroom.eclipse.org/node/add/news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Submit news
       </a>

--- a/src/templates/__tests__/__snapshots__/newsPage.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/newsPage.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`News Template page > renders correctly 1`] = `
         <div
           class="self-stretch text-center text-lightgrey text-[20px] font-normal leading-[140%] mx-auto max-w-[860px] px-2 w-full"
         >
-          Eclipse Temurin offers high-performance, cross-platform, open-source Java runtime binaries that are enterprise-ready and Java SE TCK-tested for general use in the Java ecosystem.
+          Follow the latest updates from the Eclipse Adoptium Project
         </div>
       </div>
     </div>
@@ -236,6 +236,23 @@ exports[`News Template page > renders correctly 1`] = `
             />
           </svg>
         </span>
+      </a>
+    </div>
+    <div
+      class="flex items-center gap-5"
+    >
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+      >
+        View all
+      </a>
+      |
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/node/add/news"
+      >
+        Submit news
       </a>
     </div>
   </div>

--- a/src/templates/__tests__/__snapshots__/tagPage.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/tagPage.test.tsx.snap
@@ -243,14 +243,18 @@ exports[`TagPage pages > renders correctly - with next and previous pagination 1
     >
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+        href="https://newsroom.eclipse.org/eclipse/community-news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         View all
       </a>
       |
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/node/add/news"
+        href="https://newsroom.eclipse.org/node/add/news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Submit news
       </a>
@@ -474,14 +478,18 @@ exports[`TagPage pages > renders correctly - with next pagination 1`] = `
     >
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+        href="https://newsroom.eclipse.org/eclipse/community-news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         View all
       </a>
       |
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/node/add/news"
+        href="https://newsroom.eclipse.org/node/add/news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Submit news
       </a>
@@ -733,14 +741,18 @@ exports[`TagPage pages > renders correctly - with previous pagination 1`] = `
     >
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+        href="https://newsroom.eclipse.org/eclipse/community-news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         View all
       </a>
       |
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/node/add/news"
+        href="https://newsroom.eclipse.org/node/add/news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Submit news
       </a>
@@ -964,14 +976,18 @@ exports[`TagPage pages > renders correctly 1`] = `
     >
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+        href="https://newsroom.eclipse.org/eclipse/community-news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         View all
       </a>
       |
       <a
         class="flex items-center gap-3"
-        href="/enhttps://newsroom.eclipse.org/node/add/news"
+        href="https://newsroom.eclipse.org/node/add/news"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Submit news
       </a>

--- a/src/templates/__tests__/__snapshots__/tagPage.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/tagPage.test.tsx.snap
@@ -238,6 +238,23 @@ exports[`TagPage pages > renders correctly - with next and previous pagination 1
         </span>
       </a>
     </div>
+    <div
+      class="flex items-center gap-5"
+    >
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+      >
+        View all
+      </a>
+      |
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/node/add/news"
+      >
+        Submit news
+      </a>
+    </div>
   </div>
 </main>
 `;
@@ -450,6 +467,23 @@ exports[`TagPage pages > renders correctly - with next pagination 1`] = `
             />
           </svg>
         </span>
+      </a>
+    </div>
+    <div
+      class="flex items-center gap-5"
+    >
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+      >
+        View all
+      </a>
+      |
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/node/add/news"
+      >
+        Submit news
       </a>
     </div>
   </div>
@@ -694,6 +728,23 @@ exports[`TagPage pages > renders correctly - with previous pagination 1`] = `
         </span>
       </a>
     </div>
+    <div
+      class="flex items-center gap-5"
+    >
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+      >
+        View all
+      </a>
+      |
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/node/add/news"
+      >
+        Submit news
+      </a>
+    </div>
   </div>
 </main>
 `;
@@ -906,6 +957,23 @@ exports[`TagPage pages > renders correctly 1`] = `
             />
           </svg>
         </span>
+      </a>
+    </div>
+    <div
+      class="flex items-center gap-5"
+    >
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/eclipse/community-news"
+      >
+        View all
+      </a>
+      |
+      <a
+        class="flex items-center gap-3"
+        href="/enhttps://newsroom.eclipse.org/node/add/news"
+      >
+        Submit news
       </a>
     </div>
   </div>

--- a/src/templates/newsPage.tsx
+++ b/src/templates/newsPage.tsx
@@ -25,7 +25,7 @@ const NewsPage = ({ data, pageContext }) => {
       <PageHeader
         subtitle="News"
         title="News & Updates"
-        description="Eclipse Temurin offers high-performance, cross-platform, open-source Java runtime binaries that are enterprise-ready and Java SE TCK-tested for general use in the Java ecosystem."
+        description="Follow the latest updates from the Eclipse Adoptium Project"
         className="mx-auto max-w-[860px] px-2 w-full"
       />
       <NewsCardList


### PR DESCRIPTION
# Description of change

Refer to #969 

Add missing buttons on the News pages

![image](https://github.com/user-attachments/assets/94435ddb-7c25-448c-8d3b-68b8a223e630)



## Checklist
- [X] `npm test` passes
