### PR TITLE
add revert to old site button

### DIFF
--- a/src/components/NavBar/__tests__/__snapshots__/NavBar.test.tsx.snap
+++ b/src/components/NavBar/__tests__/__snapshots__/NavBar.test.tsx.snap
@@ -237,6 +237,39 @@ exports[`NavBar component > navbar renders correctly 1`] = `
                 </span>
               </div>
             </div>
+            <div
+              class="hidden lg:flex items-center"
+            >
+              <div
+                class="relative group"
+              >
+                <button
+                  aria-label="View classic site"
+                  class="text-gray-300 rounded-full p-1.5 hover:bg-[#3E3355] transition-all border border-gray-600"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="20"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8,3 L3,8 L8,13 M12,20 L15,20 C18.3137085,20 21,17.3137085 21,14 C21,10.6862915 18.3137085,8 15,8 L4,8"
+                      fill="none"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </button>
+                <span
+                  class="absolute -left-12 bottom-full mb-2 hidden group-hover:block whitespace-nowrap rounded bg-[#3E3355] p-1 px-2 text-xs text-gray-300"
+                >
+                  View classic site
+                </span>
+              </div>
+            </div>
           </div>
           <div
             class="flex lg:hidden ml-3"

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "@headlessui/react"
 import { FaChevronDown, FaRegBell } from "react-icons/fa"
 import { BsXLg, BsList } from "react-icons/bs"
+import { GrRevert } from "react-icons/gr";
 
 import IconSocial from "../IconSocial"
 import LanguageSelector from "../LanguageSelector"
@@ -119,6 +120,21 @@ const NavBar = () => {
   const [showLastSlide, setShowLastSlide] = useState(false)
   const [showAnnouncement, setShowAnnouncement] = useState(false)
   const [activeLastSlide, setActiveLastSlide] = useState<NavItem | null>(null)
+
+  // Function to go back to the old site
+  const goToOldSite = () => {
+    if (typeof window !== 'undefined') {
+      // Set cookie to view the old site
+      const expirationDate = new Date()
+      expirationDate.setDate(expirationDate.getDate() + 30)
+      
+      // Set the Netlify cookie to 'oldsite' branch
+      document.cookie = `nf_ab=oldsite; expires=${expirationDate.toUTCString()}; path=/`
+      
+      // Reload the page to apply changes
+      window.location.reload()
+    }
+  }
 
   useEffect(() => {
     if (!mobileMenuOpen) {
@@ -249,6 +265,20 @@ const NavBar = () => {
                   <FaRegBell size={20} />
                   <span className="absolute -top-1 -right-1 h-4 w-4 bg-red-500 rounded-full text-xs text-white font-bold flex items-center justify-center">
                     1 {/* TODO: calculate the notification count */}
+                  </span>
+                </div>
+              </div>
+              <div className="hidden lg:flex items-center">
+                <div className="relative group">
+                  <button
+                    onClick={goToOldSite}
+                    className="text-gray-300 rounded-full p-1.5 hover:bg-[#3E3355] transition-all border border-gray-600"
+                    aria-label="View classic site"
+                  >
+                    <GrRevert size={20} />
+                  </button>
+                  <span className="absolute -left-12 bottom-full mb-2 hidden group-hover:block whitespace-nowrap rounded bg-[#3E3355] p-1 px-2 text-xs text-gray-300">
+                    View classic site
                   </span>
                 </div>
               </div>
@@ -423,6 +453,18 @@ const NavBar = () => {
             <ul className="flex mb-0 space-x-8 justify-center">
               <IconSocial />
             </ul>
+            <div className="mt-4 flex justify-center">
+              <div className="relative flex items-center">
+                <button
+                  onClick={goToOldSite}
+                  className="text-gray-300 rounded-full p-2 border border-gray-600 hover:bg-[#3E3355] transition-all"
+                  aria-label="View classic site"
+                >
+                  <GrRevert size={20} />
+                </button>
+                <span className="ml-2 text-xs text-gray-400">View classic site</span>
+              </div>
+            </div>
           </div>
         </DialogPanel>
       </Dialog>


### PR DESCRIPTION
# Description of change

This is a temporary measure which we should remove in the long-term. It allows users to navigate to the previous site if they are experiencing issues.

![image](https://github.com/user-attachments/assets/26b1e35f-eaaa-47b6-b139-1c3c29b479df)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
