### PR TITLE
add nightly download page back

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,6 +29,12 @@ GATSBY_CPU_COUNT = "1"
   force = true
 
 [[redirects]]
+  from = "/:locale/blog/*"
+  to = "/news/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/"
   query = {variant = ":variant"}
   to = "/temurin/releases/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@mui/lab": "^6.0.0-beta.31",
         "@mui/material": "^6.4.8",
         "@mui/x-data-grid": "^7.28.3",
-        "@mui/x-date-pickers": "^7.28.3",
         "@popperjs/core": "^2.11.8",
         "@react-icons/all-files": "^4.1.0",
         "axios": "^1.9.0",
@@ -4281,72 +4280,6 @@
           "optional": true
         },
         "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/x-date-pickers": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.28.3.tgz",
-      "integrity": "sha512-5umKB/DIMfDN+FAlzcrocix9PpoJDJ+5hMdlby8spTPObP4wCSN+wkEhk0vFC7qE9FAWXr4wjemaKvsNf41cCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-        "@mui/x-internals": "7.28.0",
-        "@types/react-transition-group": "^4.4.11",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.9.0",
-        "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
-        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
-        "dayjs": "^1.10.7",
-        "luxon": "^3.0.2",
-        "moment": "^2.29.4",
-        "moment-hijri": "^2.1.2 || ^3.0.0",
-        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        },
-        "date-fns-jalali": {
-          "optional": true
-        },
-        "dayjs": {
-          "optional": true
-        },
-        "luxon": {
-          "optional": true
-        },
-        "moment": {
-          "optional": true
-        },
-        "moment-hijri": {
-          "optional": true
-        },
-        "moment-jalaali": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@mui/lab": "^6.0.0-beta.31",
     "@mui/material": "^6.4.8",
     "@mui/x-data-grid": "^7.28.3",
-    "@mui/x-date-pickers": "^7.28.3",
     "@popperjs/core": "^2.11.8",
     "@react-icons/all-files": "^4.1.0",
     "axios": "^1.9.0",

--- a/src/components/Temurin/DownloadMethods/index.tsx
+++ b/src/components/Temurin/DownloadMethods/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { FaDocker, FaGithub } from "react-icons/fa";
+import { FaDocker, FaGithub, FaCalendarAlt } from "react-icons/fa";
 import { FcLinux, FcPackage } from "react-icons/fc";
 import { Link } from "../../Link"
 import {
@@ -72,11 +72,20 @@ const DownloadMethods = () => {
         }
       ]
     },
+        {
+      icon: <FaCalendarAlt size={35} color="#FF1365" />,
+      title: "Other Downloads",
+      buttons: [
+        {
+          "Nightly Builds": "/temurin/nightly",
+        }
+      ]
+    }
   ]
   return (
     <section className="py-16 md:py-32 bg-[#0E002A] px-6">
       <CommonHeading
-      title={"Other ways to install Temurin"}
+      title={"Other ways to download Temurin"}
       description={
         "There are multiple different ways to get Eclipse Temurin beyond direct downloads. The curated list below shows some of these options for installing high-performance, cross-platform, open-source OpenJDK runtime binaries."
       }

--- a/src/components/TemurinNightlyTable/__tests__/__snapshots__/TemurinNightlyTable.test.tsx.snap
+++ b/src/components/TemurinNightlyTable/__tests__/__snapshots__/TemurinNightlyTable.test.tsx.snap
@@ -3,59 +3,13 @@
 exports[`TemurinNightlyTable component > renders correctly - no data 1`] = `
 <div>
   <div
-    id="nightly-list"
+    class="bg-[#26193F] rounded-xl p-6 text-center"
   >
-    <table
-      class="table table-hover text-start table-striped"
-      id="nightly-table"
+    <p
+      class="text-white text-lg"
     >
-      <thead
-        class="table-dark"
-      >
-        <tr>
-          <td
-            class="fw-bold"
-          >
-            Platform
-          </td>
-          <td
-            class="fw-bold"
-          >
-            Type
-          </td>
-          <td
-            class="fw-bold"
-          >
-            Build/Tag
-          </td>
-          <td
-            class="fw-bold"
-          >
-            Date
-          </td>
-          <td
-            class="fw-bold"
-          >
-            Binary
-          </td>
-          <td
-            class="fw-bold"
-          >
-            Installer
-          </td>
-          <td
-            class="fw-bold"
-          >
-            SHA256
-          </td>
-        </tr>
-      </thead>
-      <tbody
-        class="table-light"
-      >
-        <tr />
-      </tbody>
-    </table>
+      No nightly builds available for the selected version.
+    </p>
   </div>
 </div>
 `;
@@ -63,141 +17,177 @@ exports[`TemurinNightlyTable component > renders correctly - no data 1`] = `
 exports[`TemurinNightlyTable component > renders correctly 1`] = `
 <div>
   <div
+    class="overflow-x-auto"
     id="nightly-list"
   >
-    <table
-      class="table table-hover text-start table-striped"
-      id="nightly-table"
+    <div
+      class="rounded-xl overflow-hidden mb-8 shadow-md"
     >
-      <thead
-        class="table-dark"
+      <table
+        class="min-w-full divide-y divide-gray-700"
       >
-        <tr>
-          <td
-            class="fw-bold"
-          >
-            Platform
-          </td>
-          <td
-            class="fw-bold"
-          >
-            Type
-          </td>
-          <td
-            class="fw-bold"
-          >
-            Build/Tag
-          </td>
-          <td
-            class="fw-bold"
-          >
-            Date
-          </td>
-          <td
-            class="fw-bold"
-          >
-            Binary
-          </td>
-          <td
-            class="fw-bold"
-          >
-            Installer
-          </td>
-          <td
-            class="fw-bold"
-          >
-            SHA256
-          </td>
-        </tr>
-      </thead>
-      <tbody
-        class="table-light"
-      >
-        <tr
-          class="nightly-row"
+        <thead
+          class="bg-[#200E46]"
         >
-          <td>
-            Os_mock
-             
-            architecture_mock
-          </td>
-          <td>
-            type_mock
-          </td>
-          <td>
-            release_name_mock
-          </td>
-          <td>
-            January 1, 2020
-          </td>
-          <td>
-            <a
-              href="/en/download"
-              title=""
+          <tr>
+            <th
+              class="px-6 py-4 text-left text-sm font-medium text-white tracking-wider"
+              scope="col"
             >
-              extension_mock (0 MB)
-            </a>
-          </td>
-          <td>
-            Text
-          </td>
-          <td>
-            <a
-              data-bs-checksum="checksum_mock"
-              data-bs-target="#checksumModal"
-              data-bs-toggle="modal"
-              href=""
+              Platform
+            </th>
+            <th
+              class="px-6 py-4 text-left text-sm font-medium text-white tracking-wider"
+              scope="col"
+            >
+              Type
+            </th>
+            <th
+              class="px-6 py-4 text-left text-sm font-medium text-white tracking-wider"
+              scope="col"
+            >
+              Build/Tag
+            </th>
+            <th
+              class="px-6 py-4 text-left text-sm font-medium text-white tracking-wider"
+              scope="col"
+            >
+              Date
+            </th>
+            <th
+              class="px-6 py-4 text-left text-sm font-medium text-white tracking-wider"
+              scope="col"
+            >
+              Binary
+            </th>
+            <th
+              class="px-6 py-4 text-left text-sm font-medium text-white tracking-wider"
+              scope="col"
+            >
+              Installer
+            </th>
+            <th
+              class="px-6 py-4 text-left text-sm font-medium text-white tracking-wider"
+              scope="col"
+            >
+              SHA256
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="bg-[#26193F] divide-y divide-gray-700"
+        >
+          <tr
+            class="hover:bg-[#2B1A4F] transition-colors duration-150"
+          >
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm text-gray-200"
+            >
+              Os_mock
+               
+              architecture_mock
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm text-gray-200"
+            >
+              type_mock
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm text-gray-200"
+            >
+              release_name_mock
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm text-gray-300"
+            >
+              January 1, 2020
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm"
+            >
+              <a
+                class="text-[#FF1464] hover:text-[#FF5A8F] hover:underline"
+                href="/en/download"
+                title=""
+              >
+                extension_mock (0 MB)
+              </a>
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm text-gray-400"
             >
               Text
-            </a>
-          </td>
-        </tr>
-        <tr
-          class="nightly-row"
-        >
-          <td>
-            Os_mock
-             
-            architecture_mock
-          </td>
-          <td>
-            type_mock
-          </td>
-          <td>
-            release_name_mock
-          </td>
-          <td>
-            January 1, 2020
-          </td>
-          <td>
-            <a
-              href="/en/download"
-              title=""
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm"
             >
-              extension_mock (0 MB)
-            </a>
-          </td>
-          <td>
-            <a
-              href="/en/download"
-              title=""
+              <button
+                class="text-[#FF1464] hover:text-[#FF5A8F] hover:underline cursor-pointer"
+              >
+                Text
+              </button>
+            </td>
+          </tr>
+          <tr
+            class="hover:bg-[#2B1A4F] transition-colors duration-150"
+          >
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm text-gray-200"
             >
-              installer_extension_mock
-            </a>
-          </td>
-          <td>
-            <a
-              data-bs-checksum="checksum_mock"
-              data-bs-target="#checksumModal"
-              data-bs-toggle="modal"
-              href=""
+              Os_mock
+               
+              architecture_mock
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm text-gray-200"
             >
-              Text
-            </a>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+              type_mock
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm text-gray-200"
+            >
+              release_name_mock
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm text-gray-300"
+            >
+              January 1, 2020
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm"
+            >
+              <a
+                class="text-[#FF1464] hover:text-[#FF5A8F] hover:underline"
+                href="/en/download"
+                title=""
+              >
+                extension_mock (0 MB)
+              </a>
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm"
+            >
+              <a
+                class="text-[#FF1464] hover:text-[#FF5A8F] hover:underline"
+                href="/en/download"
+                title=""
+              >
+                installer_extension_mock
+              </a>
+            </td>
+            <td
+              class="px-6 py-4 whitespace-nowrap text-sm"
+            >
+              <button
+                class="text-[#FF1464] hover:text-[#FF5A8F] hover:underline cursor-pointer"
+              >
+                Text
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/TemurinNightlyTable/index.tsx
+++ b/src/components/TemurinNightlyTable/index.tsx
@@ -5,32 +5,37 @@ import { localeDate } from "../../util/localeDate"
 import { Link } from "../Link"
 
 const getFileName = (link: URL) => {
-  return link.toString().split('/').slice(-1);
+  return link.toString().split('/').slice(-1).join('');
 }
 
-const TemurinNightlyTable = ({ results }) => {
+const TemurinNightlyTable = ({ results, openModalWithChecksum }) => {
   const { language } = useI18next()
 
+  if (!results || !results.releases || results.releases.length === 0) {
+    return (
+      <div className="bg-[#26193F] rounded-xl p-6 text-center">
+        <p className="text-white text-lg">No nightly builds available for the selected version.</p>
+      </div>
+    )
+  }
+
   return (
-    <div id="nightly-list">
-      <table
-        id="nightly-table"
-        className="table table-hover text-start table-striped"
-      >
-        <thead className="table-dark">
-          <tr>
-            <td className="fw-bold">Platform</td>
-            <td className="fw-bold">Type</td>
-            <td className="fw-bold">Build/Tag</td>
-            <td className="fw-bold">Date</td>
-            <td className="fw-bold">Binary</td>
-            <td className="fw-bold">Installer</td>
-            <td className="fw-bold">SHA256</td>
-          </tr>
-        </thead>
-        <tbody className="table-light">
-          {results && results.releases ? (
-            results.releases.map(
+    <div id="nightly-list" className="overflow-x-auto">
+      <div className="rounded-xl overflow-hidden mb-8 shadow-md">
+        <table className="min-w-full divide-y divide-gray-700">
+          <thead className="bg-[#200E46]">
+            <tr>
+              <th scope="col" className="px-6 py-4 text-left text-sm font-medium text-white tracking-wider">Platform</th>
+              <th scope="col" className="px-6 py-4 text-left text-sm font-medium text-white tracking-wider">Type</th>
+              <th scope="col" className="px-6 py-4 text-left text-sm font-medium text-white tracking-wider">Build/Tag</th>
+              <th scope="col" className="px-6 py-4 text-left text-sm font-medium text-white tracking-wider">Date</th>
+              <th scope="col" className="px-6 py-4 text-left text-sm font-medium text-white tracking-wider">Binary</th>
+              <th scope="col" className="px-6 py-4 text-left text-sm font-medium text-white tracking-wider">Installer</th>
+              <th scope="col" className="px-6 py-4 text-left text-sm font-medium text-white tracking-wider">SHA256</th>
+            </tr>
+          </thead>
+          <tbody className="bg-[#26193F] divide-y divide-gray-700">
+            {results.releases.map(
               (release, i): string | JSX.Element =>
                 release &&
                 Object.keys(release.platforms).map(function (key) {
@@ -39,33 +44,34 @@ const TemurinNightlyTable = ({ results }) => {
                       asset && (
                         <tr
                           key={`${key}-${asset.type}`}
-                          className="nightly-row"
+                          className="hover:bg-[#2B1A4F] transition-colors duration-150"
                         >
-                          <td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-200">
                             {capitalize(asset.os)}{" "}
                             {asset.architecture === "x32"
                               ? "x86"
                               : asset.architecture}
                           </td>
-                          <td>{asset.type}</td>
-                          <td>{release.release_name}</td>
-                          <td>{localeDate(release.timestamp, language)}</td>
-                          <td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-200">{asset.type}</td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-200">{release.release_name}</td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-300">{localeDate(release.timestamp, language)}</td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm">
                             <Link
                               title={getFileName(asset.link)}
                               to="/download"
                               state={{
                                 link: asset.link,
                                 checksum: asset.checksum,
-                                os: capitalize(key.split("-")[0]),
-                                arch: key.split("-")[1],
+                                os: capitalize(key.split("-")[0]?.toString() || ""),
+                                arch: key.split("-")[1]?.toString() || "",
                                 pkg_type: asset.type,
                                 java_version: "nightly",
                               }}
+                              className="text-[#FF1464] hover:text-[#FF5A8F] hover:underline"
                             >{`${asset.extension} (${asset.size} MB)`}</Link>
                           </td>
                           {asset.installer_link ? (
-                            <td>
+                            <td className="px-6 py-4 whitespace-nowrap text-sm">
                               <Link
                                 title={getFileName(asset.installer_link)}
                                 to="/download"
@@ -73,33 +79,32 @@ const TemurinNightlyTable = ({ results }) => {
                                   link: asset.installer_link,
                                   checksum: asset.installer_checksum,
                                 }}
+                                className="text-[#FF1464] hover:text-[#FF5A8F] hover:underline"
                               >
                                 {asset.installer_extension}
                               </Link>
                             </td>
                           ) : (
-                            <td><Trans i18nKey='download.not.available' defaults='Not Available' /></td>
+                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
+                              <Trans i18nKey='download.not.available' defaults='Not Available' />
+                            </td>
                           )}
-                          <td>
-                            <a
-                              href=""
-                              data-bs-toggle="modal"
-                              data-bs-target="#checksumModal"
-                              data-bs-checksum={asset.checksum}
+                          <td className="px-6 py-4 whitespace-nowrap text-sm">
+                            <button
+                              onClick={() => openModalWithChecksum && openModalWithChecksum(asset.checksum)}
+                              className="text-[#FF1464] hover:text-[#FF5A8F] hover:underline cursor-pointer"
                             >
                               <Trans>Checksum</Trans>
-                            </a>
+                            </button>
                           </td>
                         </tr>
                       ),
                   )
                 }),
-            )
-          ) : (
-            <tr></tr>
-          )}
-        </tbody>
-      </table>
+            )}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
 }

--- a/src/components/VersionSelector/__tests__/VersionSelector.test.tsx
+++ b/src/components/VersionSelector/__tests__/VersionSelector.test.tsx
@@ -6,8 +6,9 @@ import {
   fireEvent,
   prettyDOM,
 } from "@testing-library/react"
+import "@testing-library/jest-dom"
 import queryString from "query-string"
-import { afterEach, vi } from "vitest"
+import { afterEach, vi, describe, it, expect } from "vitest"
 import { useI18next } from "gatsby-plugin-react-i18next"
 import VersionSelector from "../index"
 import locales from "../../../../locales/i18n"
@@ -27,10 +28,6 @@ describe("VersionSelector", () => {
   useI18next.mockReturnValue({
     language: "en",
     languages: locales,
-  })
-
-  vi.mock("@mui/x-date-pickers/DatePicker", () => {
-    return vi.importActual("@mui/x-date-pickers/DesktopDatePicker")
   })
 
   afterEach(() => {
@@ -111,8 +108,8 @@ describe("VersionSelector", () => {
 
     await act(async () => {
       const datepicker = screen.getByLabelText("Build Date")
-      fireEvent.change(datepicker, { target: { value: "01/01/2022" } })
-      expect(datepicker.getAttribute("value")).toBe("01/01/2022")
+      fireEvent.change(datepicker, { target: { value: "2022-01-01" } })
+      expect(datepicker.getAttribute("value")).toBe("2022-01-01")
     })
 
     expect(updater).lastCalledWith("1", "ea", "10", expect.any(Date), 0)

--- a/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
+++ b/src/components/VersionSelector/__tests__/__snapshots__/VersionSelector.test.tsx.snap
@@ -2,185 +2,145 @@
 
 exports[`VersionSelector > updates the number of builds and build date when the inputs change 1`] = `
 "[36m<div>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"text-center"[39m
-  [36m/>[39m
   [36m<div[39m
-    [33mclass[39m=[32m"input-group p-3 d-flex justify-content-center"[39m
+    [33mclass[39m=[32m"max-w-3xl mx-auto my-8"[39m
   [36m>[39m
-    [36m<label[39m
-      [33mclass[39m=[32m"px-2 fw-bold"[39m
-      [33mfor[39m=[32m"version"[39m
+    [36m<h3[39m
+      [33mclass[39m=[32m"text-xl text-white mb-4 font-medium text-center"[39m
     [36m/>[39m
-    [36m<select[39m
-      [33maria-label[39m=[32m"version-filter"[39m
-      [33mclass[39m=[32m"form-select form-select-sm"[39m
-      [33mdata-testid[39m=[32m"version-filter"[39m
-      [33mid[39m=[32m"version-filter"[39m
-      [33mstyle[39m=[32m"max-width: 10em;"[39m
-    [36m>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"24"[39m
-      [36m>[39m
-        [0m24 - EA[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"23"[39m
-      [36m>[39m
-        [0m23 - EA[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"22"[39m
-      [36m>[39m
-        [0m22 - EA[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"21"[39m
-      [36m>[39m
-        [0m21 - EA[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"20"[39m
-      [36m>[39m
-        [0m20 - EA[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"19"[39m
-      [36m>[39m
-        [0m19 - EA[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"18"[39m
-      [36m>[39m
-        [0m18 - EA[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"17"[39m
-      [36m>[39m
-        [0m17 - EA[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"16"[39m
-      [36m>[39m
-        [0m16 - EA[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"2"[39m
-      [36m>[39m
-        [0m2[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"1"[39m
-      [36m>[39m
-        [0m1 - LTS[0m
-      [36m</option>[39m
-    [36m</select>[39m
-  [36m</div>[39m
-  [36m<div[39m
-    [33mclass[39m=[32m"input-group pb-5 d-flex justify-content-center"[39m
-  [36m>[39m
-    [36m<span[39m
-      [33mclass[39m=[32m"p-2"[39m
-    [36m>[39m
-      [0mView[0m
-    [36m</span>[39m
-    [36m<select[39m
-      [33maria-label[39m=[32m"Filter by number of builds"[39m
-      [33mclass[39m=[32m"form-select form-select-sm"[39m
-      [33mdata-testid[39m=[32m"build-num-filter"[39m
-      [33mid[39m=[32m"build-num-filter"[39m
-      [33mstyle[39m=[32m"max-width: 5em;"[39m
-    [36m>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"1"[39m
-      [36m>[39m
-        [0m1[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mselected[39m=[32m""[39m
-        [33mvalue[39m=[32m"5"[39m
-      [36m>[39m
-        [0m5[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"10"[39m
-      [36m>[39m
-        [0m10[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"20"[39m
-      [36m>[39m
-        [0m20[0m
-      [36m</option>[39m
-      [36m<option[39m
-        [33mvalue[39m=[32m"50"[39m
-      [36m>[39m
-        [0m50[0m
-      [36m</option>[39m
-    [36m</select>[39m
-    [36m<span[39m
-      [33mclass[39m=[32m"p-2"[39m
-    [36m>[39m
-      [0mnightly builds prior to:[0m
-    [36m</span>[39m
     [36m<div[39m
-      [33mclass[39m=[32m"MuiFormControl-root MuiTextField-root css-b8bldw-MuiFormControl-root-MuiTextField-root"[39m
+      [33mclass[39m=[32m"bg-[#26193F] rounded-xl p-6 mb-8"[39m
     [36m>[39m
-      [36m<label[39m
-        [33mclass[39m=[32m"MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"[39m
-        [33mdata-shrink[39m=[32m"true"[39m
-        [33mfor[39m=[32m":r3:"[39m
-        [33mid[39m=[32m":r3:-label"[39m
-      [36m>[39m
-        [0mBuild Date[0m
-      [36m</label>[39m
       [36m<div[39m
-        [33mclass[39m=[32m"MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"[39m
+        [33mclass[39m=[32m"flex flex-col md:flex-row md:items-end gap-6 justify-center"[39m
       [36m>[39m
-        [36m<input[39m
-          [33maria-invalid[39m=[32m"false"[39m
-          [33mautocomplete[39m=[32m"off"[39m
-          [33mclass[39m=[32m"MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"[39m
-          [33mid[39m=[32m":r3:"[39m
-          [33minputmode[39m=[32m"text"[39m
-          [33mplaceholder[39m=[32m"MM/DD/YYYY"[39m
-          [33mtype[39m=[32m"text"[39m
-          [33mvalue[39m=[32m"01/01/2022"[39m
-        [36m/>[39m
         [36m<div[39m
-          [33mclass[39m=[32m"MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"[39m
+          [33mclass[39m=[32m"w-full md:w-auto"[39m
         [36m>[39m
-          [36m<button[39m
-            [33maria-label[39m=[32m"Choose date, selected date is Jan 1, 2022"[39m
-            [33mclass[39m=[32m"MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1ysp02-MuiButtonBase-root-MuiIconButton-root"[39m
-            [33mtabindex[39m=[32m"0"[39m
-            [33mtype[39m=[32m"button"[39m
+          [36m<label[39m
+            [33mclass[39m=[32m"block text-gray-300 mb-2 font-medium"[39m
+            [33mfor[39m=[32m"version"[39m
+          [36m/>[39m
+          [36m<select[39m
+            [33maria-label[39m=[32m"version-filter"[39m
+            [33mclass[39m=[32m"w-full md:w-auto px-4 py-2 bg-[#200E46] border border-[#3E3355] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#FF1464]"[39m
+            [33mdata-testid[39m=[32m"version-filter"[39m
+            [33mid[39m=[32m"version-filter"[39m
           [36m>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"[39m
-              [33mdata-testid[39m=[32m"CalendarIcon"[39m
-              [33mfocusable[39m=[32m"false"[39m
-              [33mviewBox[39m=[32m"0 0 24 24"[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"24"[39m
             [36m>[39m
-              [36m<path[39m
-                [33md[39m=[32m"M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-          [36m</button>[39m
+              [0m24 - EA[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"23"[39m
+            [36m>[39m
+              [0m23 - EA[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"22"[39m
+            [36m>[39m
+              [0m22 - EA[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"21"[39m
+            [36m>[39m
+              [0m21 - EA[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"20"[39m
+            [36m>[39m
+              [0m20 - EA[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"19"[39m
+            [36m>[39m
+              [0m19 - EA[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"18"[39m
+            [36m>[39m
+              [0m18 - EA[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"17"[39m
+            [36m>[39m
+              [0m17 - EA[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"16"[39m
+            [36m>[39m
+              [0m16 - EA[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"2"[39m
+            [36m>[39m
+              [0m2[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"1"[39m
+            [36m>[39m
+              [0m1 - LTS[0m
+            [36m</option>[39m
+          [36m</select>[39m
         [36m</div>[39m
-        [36m<fieldset[39m
-          [33maria-hidden[39m=[32m"true"[39m
-          [33mclass[39m=[32m"MuiOutlinedInput-notchedOutline css-1ll44ll-MuiOutlinedInput-notchedOutline"[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"w-full md:w-auto"[39m
         [36m>[39m
-          [36m<legend[39m
-            [33mclass[39m=[32m"css-w1u3ce"[39m
+          [36m<label[39m
+            [33mclass[39m=[32m"block text-gray-300 mb-2 font-medium"[39m
+            [33mfor[39m=[32m"build-num-filter"[39m
+          [36m/>[39m
+          [36m<select[39m
+            [33maria-label[39m=[32m"Filter by number of builds"[39m
+            [33mclass[39m=[32m"w-full md:w-auto px-4 py-2 bg-[#200E46] border border-[#3E3355] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#FF1464]"[39m
+            [33mdata-testid[39m=[32m"build-num-filter"[39m
+            [33mid[39m=[32m"build-num-filter"[39m
           [36m>[39m
-            [36m<span>[39m
-              [0mBuild Date[0m
-            [36m</span>[39m
-          [36m</legend>[39m
-        [36m</fieldset>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"1"[39m
+            [36m>[39m
+              [0m1[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mselected[39m=[32m""[39m
+              [33mvalue[39m=[32m"5"[39m
+            [36m>[39m
+              [0m5[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"10"[39m
+            [36m>[39m
+              [0m10[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"20"[39m
+            [36m>[39m
+              [0m20[0m
+            [36m</option>[39m
+            [36m<option[39m
+              [33mvalue[39m=[32m"50"[39m
+            [36m>[39m
+              [0m50[0m
+            [36m</option>[39m
+          [36m</select>[39m
+        [36m</div>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"w-full md:w-auto"[39m
+        [36m>[39m
+          [36m<label[39m
+            [33mclass[39m=[32m"block text-gray-300 mb-2 font-medium"[39m
+            [33mfor[39m=[32m"build-date"[39m
+          [36m/>[39m
+          [36m<input[39m
+            [33maria-label[39m=[32m"Build Date"[39m
+            [33mclass[39m=[32m"w-full md:w-auto px-4 py-2 bg-[#200E46] border border-[#3E3355] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#FF1464] date-picker"[39m
+            [33mid[39m=[32m"build-date"[39m
+            [33mmax[39m=[32m"2025-05-23"[39m
+            [33mtype[39m=[32m"date"[39m
+            [33mvalue[39m=[32m"2022-01-01"[39m
+          [36m/>[39m
+        [36m</div>[39m
       [36m</div>[39m
     [36m</div>[39m
   [36m</div>[39m

--- a/src/components/VersionSelector/index.tsx
+++ b/src/components/VersionSelector/index.tsx
@@ -3,10 +3,6 @@ import { useStaticQuery, graphql } from "gatsby"
 import { Trans, useI18next } from "gatsby-plugin-react-i18next"
 import { useLocation } from "@gatsbyjs/reach-router"
 import queryString from "query-string"
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3'
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider"
-import { DesktopDatePicker } from "@mui/x-date-pickers/DesktopDatePicker"
-import * as Locales from 'date-fns/locale'
 
 import { setURLParam } from "../../util/setURLParam"
 
@@ -36,13 +32,6 @@ const VersionSelector = ({ updater, releaseType, Table }) => {
   const versions = data.allVersions.edges
 
   const { language } = useI18next()
-
-  let locale
-
-  // import the correct date locale for the language
-  if (language !== "en") {
-    locale = Locales[language] ?? Locales[language.substring(0, 2)] ?? Locales.enUS
-  }
 
   let selectedVersion = defaultVersion
   const versionParam = queryString.parse(useLocation().search).version
@@ -111,82 +100,91 @@ const VersionSelector = ({ updater, releaseType, Table }) => {
 
   return (
     <>
-      <p className="text-center">
-        <Trans>
-          Use the drop-down boxes below to filter the list of releases.
-        </Trans>
-      </p>
-      <div className="input-group p-3 d-flex justify-content-center">
-        <label className="px-2 fw-bold" htmlFor="version">
-          <Trans>Version</Trans>
-        </label>
-        <select
-          data-testid="version-filter"
-          aria-label="version-filter"
-          id="version-filter"
-          onChange={e => setVersion(e.target.value)}
-          value={version}
-          className="form-select form-select-sm"
-          style={{ maxWidth: "10em" }}
-        >
-          {/* loop through versions array from graphql */}
-          {versionsToDisplay.map(
-            (version, i): number | JSX.Element =>
-              version && (
-                <option key={version.node.id} value={version.node.version}>
-                  {version.node.label}
-                </option>
-              ),
-          )}
-        </select>
-      </div>
-      {releaseType === "ea" && (
-        <div className="input-group pb-5 d-flex justify-content-center">
-          <span className="p-2">View</span>
-          <select
-            data-testid="build-num-filter"
-            aria-label="Filter by number of builds"
-            id="build-num-filter"
-            onChange={e => setNumBuilds(e.target.value)}
-            defaultValue={numBuilds}
-            className="form-select form-select-sm"
-            style={{ maxWidth: "5em" }}
-          >
-            <option key={1} value={1}>
-              1
-            </option>
-            <option key={5} value={5}>
-              5
-            </option>
-            <option key={10} value={10}>
-              10
-            </option>
-            <option key={20} value={20}>
-              20
-            </option>
-            <option key={50} value={50}>
-              50
-            </option>
-          </select>
-          <span className="p-2">nightly builds prior to:</span>
-          <LocalizationProvider
-            dateAdapter={AdapterDateFns}
-            adapterLocale={locale}
-          >
-            <DesktopDatePicker
-              label="Build Date"
-              value={buildDate}
-              maxDate={new Date()}
-              onChange={newValue => {
-                newValue && updateBuildDate(newValue)
-              }}
-              sx={{
-                maxWidth: "10em",
-              }}
-            />
-          </LocalizationProvider>
+      <div className="max-w-3xl mx-auto my-8">
+        <h3 className="text-xl text-white mb-4 font-medium text-center">
+          <Trans>
+            Select options to filter the list of nightly builds
+          </Trans>
+        </h3>
+        
+        <div className="bg-[#26193F] rounded-xl p-6 mb-8">
+          <div className="flex flex-col md:flex-row md:items-end gap-6 justify-center">
+            <div className="w-full md:w-auto">
+              <label className="block text-gray-300 mb-2 font-medium" htmlFor="version">
+                <Trans>Version</Trans>
+              </label>
+              <select
+                data-testid="version-filter"
+                aria-label="version-filter"
+                id="version-filter"
+                onChange={e => setVersion(e.target.value)}
+                value={version}
+                className="w-full md:w-auto px-4 py-2 bg-[#200E46] border border-[#3E3355] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#FF1464]"
+              >
+                {/* loop through versions array from graphql */}
+                {versionsToDisplay.map(
+                  (version, i): number | JSX.Element =>
+                    version && (
+                      <option key={version.node.id || i} value={version.node.version}>
+                        {version.node.label}
+                      </option>
+                    ),
+                )}
+              </select>
+            </div>
+            
+            {releaseType === "ea" && (
+              <>
+                <div className="w-full md:w-auto">
+                  <label className="block text-gray-300 mb-2 font-medium" htmlFor="build-num-filter">
+                    <Trans>Number of builds</Trans>
+                  </label>
+                  <select
+                    data-testid="build-num-filter"
+                    aria-label="Filter by number of builds"
+                    id="build-num-filter"
+                    onChange={e => setNumBuilds(e.target.value)}
+                    defaultValue={numBuilds}
+                    className="w-full md:w-auto px-4 py-2 bg-[#200E46] border border-[#3E3355] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#FF1464]"
+                  >
+                    <option key={1} value={1}>1</option>
+                    <option key={5} value={5}>5</option>
+                    <option key={10} value={10}>10</option>
+                    <option key={20} value={20}>20</option>
+                    <option key={50} value={50}>50</option>
+                  </select>
+                </div>
+
+                <div className="w-full md:w-auto">
+                  <label className="block text-gray-300 mb-2 font-medium" htmlFor="build-date">
+                  <Trans>Builds prior to</Trans>
+                  </label>
+                  <input
+                  id="build-date"
+                  type="date"
+                  className="w-full md:w-auto px-4 py-2 bg-[#200E46] border border-[#3E3355] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#FF1464] date-picker"
+                  value={buildDate.toISOString().split("T")[0]}
+                  max={new Date().toISOString().split("T")[0]}
+                  aria-label="Build Date"
+                  onChange={e => {
+                    const date = new Date(e.target.value)
+                    if (!isNaN(date.getTime())) {
+                    updateBuildDate(date)
+                    }
+                  }}
+                  />
+                  <style>{`
+                  .date-picker::-webkit-calendar-picker-indicator {
+                    filter: invert(39%) sepia(76%) saturate(7464%) hue-rotate(324deg) brightness(98%) contrast(105%);
+                  }
+                  `}</style>
+                </div>
+              </>
+            )}
+          </div>
         </div>
-      )}
+      </div>
+      
       <Table results={releases} updatePage={updatePage} />
     </>
   )

--- a/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/nightly.test.tsx.snap
@@ -2,328 +2,301 @@
 
 exports[`Temurin Nightly page > renders correctly 1`] = `
 <main>
-  <section
-    class="py-5 text-center container"
+  <div
+    class="relative pt-40 pb-16 md:pb-36 md:pt-60 overflow-hidden"
   >
     <div
-      class="row py-lg-5"
+      class="w-full relative"
     >
       <div
-        class="col-lg-10 col-md-8 mx-auto"
+        class="absolute z-[-1] w-[2396px] h-[1340px] left-[23px] md:left-[112px] top-[21px] md:top-[171px] bg-[#410170] shadow-[0_0_400px_rgba(65,1,112,1)] rounded-full blur-[400px]"
+      />
+      <div
+        class="absolute z-[-1] w-[1487px] h-[893px] left-[120px] md:left-[676px] top-[120px] md:top-[395px] bg-[#B62987] shadow-[0_0_400px_rgba(182,41,135,1)] rounded-full blur-[400px]"
+      />
+      <div
+        class="absolute z-[-1] w-[688px] h-[446px] left-[400px] md:left-[1131px] top-[618px] bg-[#FE8492] shadow-[0_0_400px_rgba(254,132,146,1)] rounded-full blur-[400px]"
+      />
+    </div>
+    <div
+      class="mx-auto max-w-[1048px] w-full px-6 lg:px-0 flex flex-col items-center justify-center"
+    >
+      <div
+        class="self-stretch flex-col justify-center items-center gap-6 flex"
       >
-        <h1
-          class="fw-light"
-        >
-          Nightly builds
-        </h1>
         <div
-          class="row align-items-center pt-2"
+          class="self-stretch  flex-col justify-center items-center gap-4 flex"
         >
           <div
-            class="callout callout-default text-start"
+            class="justify-start items-center gap-3 inline-flex"
           >
-            Text
-            <br />
-            <br />
-            Text
-            <br />
-            “
-            Text
-            ”
-            <br />
-            <br />
-            <p
-              class="text-warning"
+            <svg
+              fill="none"
+              height="14"
+              viewBox="0 0 14 14"
+              width="14"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Text
-            </p>
+              <rect
+                fill="#FF1464"
+                height="8"
+                rx="2"
+                width="8"
+                x="3"
+                y="3"
+              />
+              <rect
+                height="11"
+                rx="3.5"
+                stroke="#FF1464"
+                stroke-opacity="0.25"
+                stroke-width="3"
+                width="11"
+                x="1.5"
+                y="1.5"
+              />
+            </svg>
+            <div
+              class="text-rose-600 text-base font-bold leading-normal"
+            >
+              Early Access
+            </div>
           </div>
           <div
-            class="btn-group"
+            class="self-stretch text-center text-white   text-[56px] lg:text-[80px] leading-[114.286%] md:leading-[120%] font-semibold"
           >
-            <a
-              class="btn btn-primary m-3"
-              href="/en/temurin/releases"
-            >
-              Text
-               
-              <svg
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 512 512"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M256 8c137 0 248 111 248 248S393 504 256 504 8 393 8 256 119 8 256 8zm-28.9 143.6l75.5 72.4H120c-13.3 0-24 10.7-24 24v16c0 13.3 10.7 24 24 24h182.6l-75.5 72.4c-9.7 9.3-9.9 24.8-.4 34.3l11 10.9c9.4 9.4 24.6 9.4 33.9 0L404.3 273c9.4-9.4 9.4-24.6 0-33.9L271.6 106.3c-9.4-9.4-24.6-9.4-33.9 0l-11 10.9c-9.5 9.6-9.3 25.1.4 34.4z"
-                />
-              </svg>
-            </a>
-            <a
-              class="btn btn-secondary m-3"
-              href="/en/temurin/archive"
-            >
-              Text
-               
-              <svg
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 512 512"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M256 8c137 0 248 111 248 248S393 504 256 504 8 393 8 256 119 8 256 8zm-28.9 143.6l75.5 72.4H120c-13.3 0-24 10.7-24 24v16c0 13.3 10.7 24 24 24h182.6l-75.5 72.4c-9.7 9.3-9.9 24.8-.4 34.3l11 10.9c9.4 9.4 24.6 9.4 33.9 0L404.3 273c9.4-9.4 9.4-24.6 0-33.9L271.6 106.3c-9.4-9.4-24.6-9.4-33.9 0l-11 10.9c-9.5 9.6-9.3 25.1.4 34.4z"
-                />
-              </svg>
-            </a>
+            Nightly Builds
           </div>
+        </div>
+        <div
+          class="self-stretch text-center text-lightgrey text-[20px] font-normal leading-[140%] undefined"
+        >
+          Get the latest nightly builds for testing and development purposes.
         </div>
       </div>
     </div>
-    <p
-      class="text-center"
-    >
-      Text
-    </p>
+  </div>
+  <div
+    class="max-w-[1264px] mx-auto px-6 py-8"
+  >
     <div
-      class="input-group p-3 d-flex justify-content-center"
+      class="bg-[#26193F] rounded-2xl p-6 md:p-8 mb-10"
     >
-      <label
-        class="px-2 fw-bold"
-        for="version"
+      <div
+        class="prose prose-invert max-w-none"
       >
         Text
-      </label>
-      <select
-        aria-label="version-filter"
-        class="form-select form-select-sm"
-        data-testid="version-filter"
-        id="version-filter"
-        style="max-width: 10em;"
+        <h4
+          class="mt-6 mb-3 text-lg font-medium"
+        >
+          Text
+        </h4>
+        <blockquote
+          class="border-l-4 border-gray-500 pl-4 italic my-4"
+        >
+          Text
+        </blockquote>
+        <div
+          class="bg-amber-900/30 border-l-4 border-amber-600 p-4 mt-6"
+        >
+          <p
+            class="text-amber-400 font-medium"
+          >
+            Text
+          </p>
+        </div>
+      </div>
+      <div
+        class="flex flex-wrap gap-4 mt-8"
       >
-        <option
-          value="24"
+        <a
+          class="rounded-[80px] bg-[#FF1464] border transition duration-300 ease-in-out hover:bg-transparent hover:text-[#FF1464] border-[#FF1464] flex items-center justify-center gap-3 px-6 py-3 text-white font-bold leading-6 text-base"
+          href="/en/temurin/releases"
         >
-          24 - EA
-        </option>
-        <option
-          value="23"
-        >
-          23 - EA
-        </option>
-        <option
-          value="22"
-        >
-          22 - EA
-        </option>
-        <option
-          value="21"
-        >
-          21 - EA
-        </option>
-        <option
-          value="20"
-        >
-          20 - EA
-        </option>
-        <option
-          value="19"
-        >
-          19 - EA
-        </option>
-        <option
-          value="18"
-        >
-          18 - EA
-        </option>
-        <option
-          value="17"
-        >
-          17 - EA
-        </option>
-        <option
-          value="16"
-        >
-          16 - EA
-        </option>
-        <option
-          value="2"
-        >
-          2
-        </option>
-        <option
-          value="1"
-        >
-          1 - LTS
-        </option>
-      </select>
+          Text
+           
+          <svg
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 512 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 8c137 0 248 111 248 248S393 504 256 504 8 393 8 256 119 8 256 8zm-28.9 143.6l75.5 72.4H120c-13.3 0-24 10.7-24 24v16c0 13.3 10.7 24 24 24h182.6l-75.5 72.4c-9.7 9.3-9.9 24.8-.4 34.3l11 10.9c9.4 9.4 24.6 9.4 33.9 0L404.3 273c9.4-9.4 9.4-24.6 0-33.9L271.6 106.3c-9.4-9.4-24.6-9.4-33.9 0l-11 10.9c-9.5 9.6-9.3 25.1.4 34.4z"
+            />
+          </svg>
+        </a>
+      </div>
     </div>
     <div
-      class="input-group pb-5 d-flex justify-content-center"
+      class="max-w-3xl mx-auto my-8"
     >
-      <span
-        class="p-2"
+      <h3
+        class="text-xl text-white mb-4 font-medium text-center"
       >
-        View
-      </span>
-      <select
-        aria-label="Filter by number of builds"
-        class="form-select form-select-sm"
-        data-testid="build-num-filter"
-        id="build-num-filter"
-        style="max-width: 5em;"
-      >
-        <option
-          value="1"
-        >
-          1
-        </option>
-        <option
-          selected=""
-          value="5"
-        >
-          5
-        </option>
-        <option
-          value="10"
-        >
-          10
-        </option>
-        <option
-          value="20"
-        >
-          20
-        </option>
-        <option
-          value="50"
-        >
-          50
-        </option>
-      </select>
-      <span
-        class="p-2"
-      >
-        nightly builds prior to:
-      </span>
+        Text
+      </h3>
       <div
-        class="MuiFormControl-root MuiTextField-root css-b8bldw-MuiFormControl-root-MuiTextField-root"
+        class="bg-[#26193F] rounded-xl p-6 mb-8"
       >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
-          data-shrink="true"
-          for=":r0:"
-          id=":r0:-label"
-        >
-          Build Date
-        </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd css-jupps9-MuiInputBase-root-MuiOutlinedInput-root"
+          class="flex flex-col md:flex-row md:items-end gap-6 justify-center"
         >
-          <input
-            aria-invalid="false"
-            autocomplete="off"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
-            id=":r0:"
-            inputmode="text"
-            placeholder="MM/DD/YYYY"
-            type="text"
-            value="01/01/2022"
-          />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
+            class="w-full md:w-auto"
           >
-            <button
-              aria-label="Choose date, selected date is Jan 1, 2022"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1ysp02-MuiButtonBase-root-MuiIconButton-root"
-              tabindex="0"
-              type="button"
+            <label
+              class="block text-gray-300 mb-2 font-medium"
+              for="version"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-                data-testid="CalendarIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              Text
+            </label>
+            <select
+              aria-label="version-filter"
+              class="w-full md:w-auto px-4 py-2 bg-[#200E46] border border-[#3E3355] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#FF1464]"
+              data-testid="version-filter"
+              id="version-filter"
+            >
+              <option
+                value="24"
               >
-                <path
-                  d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"
-                />
-              </svg>
-            </button>
+                24 - EA
+              </option>
+              <option
+                value="23"
+              >
+                23 - EA
+              </option>
+              <option
+                value="22"
+              >
+                22 - EA
+              </option>
+              <option
+                value="21"
+              >
+                21 - EA
+              </option>
+              <option
+                value="20"
+              >
+                20 - EA
+              </option>
+              <option
+                value="19"
+              >
+                19 - EA
+              </option>
+              <option
+                value="18"
+              >
+                18 - EA
+              </option>
+              <option
+                value="17"
+              >
+                17 - EA
+              </option>
+              <option
+                value="16"
+              >
+                16 - EA
+              </option>
+              <option
+                value="2"
+              >
+                2
+              </option>
+              <option
+                value="1"
+              >
+                1 - LTS
+              </option>
+            </select>
           </div>
-          <fieldset
-            aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-1ll44ll-MuiOutlinedInput-notchedOutline"
+          <div
+            class="w-full md:w-auto"
           >
-            <legend
-              class="css-w1u3ce"
+            <label
+              class="block text-gray-300 mb-2 font-medium"
+              for="build-num-filter"
             >
-              <span>
-                Build Date
-              </span>
-            </legend>
-          </fieldset>
+              Text
+            </label>
+            <select
+              aria-label="Filter by number of builds"
+              class="w-full md:w-auto px-4 py-2 bg-[#200E46] border border-[#3E3355] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#FF1464]"
+              data-testid="build-num-filter"
+              id="build-num-filter"
+            >
+              <option
+                value="1"
+              >
+                1
+              </option>
+              <option
+                selected=""
+                value="5"
+              >
+                5
+              </option>
+              <option
+                value="10"
+              >
+                10
+              </option>
+              <option
+                value="20"
+              >
+                20
+              </option>
+              <option
+                value="50"
+              >
+                50
+              </option>
+            </select>
+          </div>
+          <div
+            class="w-full md:w-auto"
+          >
+            <label
+              class="block text-gray-300 mb-2 font-medium"
+              for="build-date"
+            >
+              Text
+            </label>
+            <input
+              aria-label="Build Date"
+              class="w-full md:w-auto px-4 py-2 bg-[#200E46] border border-[#3E3355] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#FF1464] date-picker"
+              id="build-date"
+              max="2025-05-23"
+              type="date"
+              value="2022-01-01"
+            />
+            <style>
+              
+                  .date-picker::-webkit-calendar-picker-indicator {
+                    filter: invert(39%) sepia(76%) saturate(7464%) hue-rotate(324deg) brightness(98%) contrast(105%);
+                  }
+                  
+            </style>
+          </div>
         </div>
       </div>
     </div>
     <div
-      id="nightly-list"
+      class="bg-[#26193F] rounded-xl p-6 text-center"
     >
-      <table
-        class="table table-hover text-start table-striped"
-        id="nightly-table"
+      <p
+        class="text-white text-lg"
       >
-        <thead
-          class="table-dark"
-        >
-          <tr>
-            <td
-              class="fw-bold"
-            >
-              Platform
-            </td>
-            <td
-              class="fw-bold"
-            >
-              Type
-            </td>
-            <td
-              class="fw-bold"
-            >
-              Build/Tag
-            </td>
-            <td
-              class="fw-bold"
-            >
-              Date
-            </td>
-            <td
-              class="fw-bold"
-            >
-              Binary
-            </td>
-            <td
-              class="fw-bold"
-            >
-              Installer
-            </td>
-            <td
-              class="fw-bold"
-            >
-              SHA256
-            </td>
-          </tr>
-        </thead>
-        <tbody
-          class="table-light"
-        />
-      </table>
+        No nightly builds available for the selected version.
+      </p>
     </div>
-  </section>
+  </div>
 </main>
 `;

--- a/src/pages/temurin/__tests__/__snapshots__/releases.test.tsx.snap
+++ b/src/pages/temurin/__tests__/__snapshots__/releases.test.tsx.snap
@@ -305,7 +305,7 @@ exports[`Releases page > renders correctly 1`] = `
       <h2
         class="text-4xl leading-[122%] md:text-5xl md:[116%] text-white font-semibold"
       >
-        Other ways to install Temurin
+        Other ways to download Temurin
       </h2>
       <p
         class="text-grey mt-6 font-normal text-base"
@@ -680,6 +680,46 @@ exports[`Releases page > renders correctly 1`] = `
                 target="_blank"
               >
                 setup-java
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex gap-4 max-w-[366px] xl:max-w-[322px]"
+        >
+          <span
+            class="p-6 rounded-full cursor-pointer flex justify-center items-center w-fit bg-[#2B1A4F] border border-[#5A4D76]"
+          >
+            <svg
+              color="#FF1365"
+              fill="currentColor"
+              height="35"
+              stroke="currentColor"
+              stroke-width="0"
+              style="color: rgb(255, 19, 101);"
+              viewBox="0 0 448 512"
+              width="35"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0 464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V192H0v272zm320-196c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM192 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM64 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zM400 64h-48V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H160V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H48C21.5 64 0 85.5 0 112v48h448v-48c0-26.5-21.5-48-48-48z"
+              />
+            </svg>
+          </span>
+          <div>
+            <h3
+              class="max-w-[270px] text-xl font-normal xl:max-w-[226px]"
+            >
+              Other Downloads
+            </h3>
+            <div
+              class="flex gap-4 mt-2 "
+            >
+              <a
+                class="text-[#FF1464] text-sm font-normal border-b-[1px] border-[#FF1464]"
+                href="/en/temurin/nightly"
+              >
+                Nightly Builds
               </a>
             </div>
           </div>

--- a/src/pages/temurin/__tests__/nightly.test.tsx
+++ b/src/pages/temurin/__tests__/nightly.test.tsx
@@ -1,7 +1,9 @@
 import React from "react"
 import { act, render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { axe } from "vitest-axe"
+import "vitest-axe/extend-expect"
 import Nightly, { Head } from "../nightly"
 import AxiosInstance from "axios"
 import MockAdapter from "axios-mock-adapter"
@@ -22,8 +24,8 @@ describe("Temurin Nightly page", () => {
 
     await act(async () => {
       const datepicker = screen.getByLabelText("Build Date")
-      fireEvent.change(datepicker, { target: { value: "01/01/2022" } })
-      expect(datepicker.getAttribute("value")).toBe("01/01/2022")
+      fireEvent.change(datepicker, { target: { value: "2022-01-01" } })
+      expect(datepicker.getAttribute("value")).toBe("2022-01-01")
     })
 
     expect(pageContent).toMatchSnapshot()

--- a/src/pages/temurin/nightly.tsx
+++ b/src/pages/temurin/nightly.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React, { useState } from "react"
 import { graphql } from "gatsby"
 import { Trans } from "gatsby-plugin-react-i18next"
 import { FaArrowCircleRight } from "react-icons/fa"
@@ -10,51 +10,92 @@ import VersionSelector from "../../components/VersionSelector"
 import ChecksumModal from "../../components/ChecksumModal"
 import TemurinNightlyTable from "../../components/TemurinNightlyTable"
 import { getAssetsForVersion } from "../../hooks"
-import LinkText from '../../components/LinkText'
+import LinkText from "../../components/LinkText"
+import PageHeader from "../../components/PageHeader"
 
-const TemurinReleases = () => (
-  <Layout>
-    <section className='py-5 text-center container'>
-      <div className='row py-lg-5'>
-        <div className='col-lg-10 col-md-8 mx-auto'>
-          <h1 className='fw-light'>Nightly builds</h1>
-          <div className='row align-items-center pt-2'>
-            <div className='callout callout-default text-start'>
-              <Trans i18nKey='nightly.builds.be.aware' defaults='Please be aware that this archive contains intermediate builds created as a development step towards a <fullReleaseLink>full release</fullReleaseLink>. Intermediate builds are ephemeral, and may disappear in the future.' 
-                components= {{
-                  fullReleaseLink: <LinkText href='/temurin/releases' />
-                }}
+const TemurinNightly = () => {
+  const [modalOpen, setModalOpen] = useState(false)
+  const [currentChecksum, setCurrentChecksum] = useState("")
+
+  const openModalWithChecksum = checksum => {
+    setCurrentChecksum(checksum)
+    setModalOpen(true)
+  }
+
+  return (
+    <Layout>
+      <PageHeader
+        title="Nightly Builds"
+        subtitle="Early Access"
+        description="Get the latest nightly builds for testing and development purposes."
+      />
+      
+      <div className="max-w-[1264px] mx-auto px-6 py-8">
+        <div className="bg-[#26193F] rounded-2xl p-6 md:p-8 mb-10">
+          <div className="prose prose-invert max-w-none">
+            <Trans 
+              i18nKey="nightly.builds.be.aware" 
+              defaults="Please be aware that this archive contains intermediate builds created as a development step towards a <fullReleaseLink>full release</fullReleaseLink>. Intermediate builds are ephemeral, and may disappear in the future."
+              components={{
+                fullReleaseLink: <LinkText href="/temurin/releases" />
+              }}
+            />
+            
+            <h4 className="mt-6 mb-3 text-lg font-medium">
+              <Trans i18nKey="nightly.builds.notice.title" defaults="The following notice applies to intermediate builds:" />
+            </h4>
+            
+            <blockquote className="border-l-4 border-gray-500 pl-4 italic my-4">
+              <Trans 
+                i18nKey="nightly.builds.quoted.notice" 
+                defaults="This is an intermediate build made available for testing purposes only. The code is untested and presumed incompatible with the Java SE specification.
+                You should not deploy or write to this code, but instead use the tested and certified Java SE compatible version of the code.
+                Redistribution of this build must retain this notice." 
               />
-              <br />
-              <br />
-              <Trans i18nKey='nightly.builds.notice.title' defaults='The following notice applies to intermediate builds:' />
-              <br />
-              &ldquo;<Trans i18nKey='nightly.builds.quoted.notice' defaults='This is an intermediate build made available for testing purposes only. The code is untested and presumed incompatible with the Java SE specification.
-              You should not deploy or write to this code, but instead use the tested and certified Java SE compatible version of the code.
-              Redistribution of this build must retain this notice.' />&rdquo;
-              <br />
-              <br />
-              <p className='text-warning'>
-                <Trans i18nKey='nightly.builds.unsupported.in.production' defaults='These builds are unsupported and not for use in production.' /></p>
-            </div>
-            <div className='btn-group'>
-              <Link to='/temurin/releases' className='btn btn-primary m-3'>
-                <Trans>Latest Releases</Trans> <FaArrowCircleRight />
-              </Link>
-              <Link to='/temurin/archive' className='btn btn-secondary m-3'>
-                <Trans>Release Archive</Trans> <FaArrowCircleRight />
-              </Link>
+            </blockquote>
+            
+            <div className="bg-amber-900/30 border-l-4 border-amber-600 p-4 mt-6">
+              <p className="text-amber-400 font-medium">
+                <Trans 
+                  i18nKey="nightly.builds.unsupported.in.production" 
+                  defaults="These builds are unsupported and not for use in production." 
+                />
+              </p>
             </div>
           </div>
+          
+          <div className="flex flex-wrap gap-4 mt-8">
+            <Link 
+              to="/temurin/releases" 
+              className="rounded-[80px] bg-[#FF1464] border transition duration-300 ease-in-out hover:bg-transparent hover:text-[#FF1464] border-[#FF1464] flex items-center justify-center gap-3 px-6 py-3 text-white font-bold leading-6 text-base"
+            >
+              <Trans>Latest Releases</Trans> <FaArrowCircleRight />
+            </Link>
+            {/* <Link 
+              to="/temurin/archive" 
+              className="rounded-[80px] bg-transparent border-2 border-[#3E3355] hover:border-[#FF1464] hover:text-[#FF1464] transition duration-300 flex items-center justify-center gap-3 px-6 py-3 text-white font-bold leading-6 text-base"
+            >
+              <Trans>Release Archive</Trans> <FaArrowCircleRight />
+            </Link> */}
+          </div>
         </div>
-      </div>
-      <VersionSelector updater={getAssetsForVersion} releaseType='ea' Table={TemurinNightlyTable} />
-      {/* <ChecksumModal /> */}
-    </section>
-  </Layout>
-)
 
-export default TemurinReleases
+        <VersionSelector 
+          updater={getAssetsForVersion} 
+          releaseType="ea" 
+          Table={props => <TemurinNightlyTable {...props} openModalWithChecksum={openModalWithChecksum} />} 
+        />
+        <ChecksumModal
+          open={modalOpen}
+          setOpen={setModalOpen}
+          checksum={currentChecksum}
+        />
+      </div>
+    </Layout>
+  )
+}
+
+export default TemurinNightly
 
 export const Head = () => <Seo title="Nightly Builds" />
 


### PR DESCRIPTION
# Description of change

I realised in our eagerness to release the new website we missed the nightly download page. This could probably do with a re-think in the long term with an emphasis on "EA" releases but for now in order to preserve functionality this "face lifted" page will do.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
