### PR TITLE
Group dependendabot deps for easier upgrading

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  groups:
+      gatsby-dependencies:
+        patterns:
+          - "gatsby-plugin-*"
+      mui-dependencies:
+        patterns:
+          - "@mui/*"
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"


### PR DESCRIPTION
Now that https://github.blog/changelog/2023-06-29-grouped-version-updates-for-dependabot-public-beta/ is a thing we can group the deps

# Description of change

<!--
Thank you for your pull request. Please provide a description of the change here and review
the requirements below.
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
