### PR TITLE
Add footnotes back to supported platforms

### DIFF
--- a/src/components/Support/PlatformMatrix/index.tsx
+++ b/src/components/Support/PlatformMatrix/index.tsx
@@ -6,6 +6,15 @@ import { LiaTimesSolid } from "react-icons/lia"
 import { HiChevronDown } from "react-icons/hi2"
 import platformSupportData from "../../../json/supported-platforms.json"
 
+interface Platform {
+  category: string
+  footnotes?: string[]
+  distros: Array<{
+    name: string
+    versions: Record<string, { supported: boolean; docker: boolean }>
+  }>
+}
+
 const PlatformMatrix = () => {
   const [openFaq, setOpenFaq] = useState(null)
 
@@ -15,6 +24,29 @@ const PlatformMatrix = () => {
 
   const isEven = n => {
     return n % 2 == 0
+  }
+
+  // Helper function to render text with clickable links
+  const renderTextWithLinks = (text: string) => {
+    const urlRegex = /(https?:\/\/[^\s]+)/g
+    const parts = text.split(urlRegex)
+    
+    return parts.map((part, index) => {
+      if (urlRegex.test(part)) {
+        return (
+          <a
+            key={index}
+            href={part}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-pink-300 hover:text-pink-200 underline transition-colors duration-200"
+          >
+            {part}
+          </a>
+        )
+      }
+      return part
+    })
   }
 
   return (
@@ -99,6 +131,21 @@ const PlatformMatrix = () => {
               >
                 {openFaq === index && (
                   <div className="px-4 md:px-6 lg:px-8 pb-4 md:pb-6 lg:pb-8">
+                    {/* Footnotes section */}
+                    {(platform as any).footnotes && (platform as any).footnotes.length > 0 && (
+                      <div className="my-4 p-4 bg-gradient-to-r from-pink-900/20 to-rose-900/20 border border-pink-500/20 rounded-xl">
+                        <div className="flex items-start gap-3">
+                          <div className="flex-shrink-0 w-2 h-2 bg-pink-400 rounded-full mt-2"></div>
+                          <div className="text-pink-100/90 text-sm leading-relaxed">
+                            {(platform as any).footnotes.map((footnote: string, index: number) => (
+                              <div key={index} className={index > 0 ? 'mt-2' : ''}>
+                                {renderTextWithLinks(footnote)}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    )}
                     <div className="hidden md:block bg-gradient-to-br from-black/20 to-black/10 rounded-2xl border border-white/5 overflow-hidden">
                       {platform.distros.map((distro, distroIndex) => (
                         <div

--- a/src/json/supported-platforms.json
+++ b/src/json/supported-platforms.json
@@ -4,6 +4,16 @@
       "category": "Windows (x64)",
       "distros": [
         {
+          "name": "Windows Server 2025",
+          "versions": {
+            "8": { "supported": true, "docker": true },
+            "11": { "supported": true, "docker": true },
+            "17": { "supported": true, "docker": true },
+            "21": { "supported": true, "docker": true },
+            "24": { "supported": true, "docker": true }
+          }
+        },
+        {
           "name": "Windows Server 2022",
           "versions": {
             "8": { "supported": true, "docker": true },
@@ -15,16 +25,6 @@
         },
         {
           "name": "Windows Server 2019",
-          "versions": {
-            "8": { "supported": true, "docker": true },
-            "11": { "supported": true, "docker": true },
-            "17": { "supported": true, "docker": true },
-            "21": { "supported": true, "docker": true },
-            "24": { "supported": true, "docker": true }
-          }
-        },
-        {
-          "name": "Windows Server 2016",
           "versions": {
             "8": { "supported": true, "docker": false },
             "11": { "supported": true, "docker": false },
@@ -59,6 +59,16 @@
       "category": "Windows (aarch64)",
       "distros": [
         {
+          "name": "Windows Server 2025",
+          "versions": {
+            "8": { "supported": false, "docker": false },
+            "11": { "supported": false, "docker": false },
+            "17": { "supported": false, "docker": false },
+            "21": { "supported": true, "docker": false },
+            "24": { "supported": false, "docker": false }
+          }
+        },
+        {
           "name": "Windows Server 2022",
           "versions": {
             "8": { "supported": false, "docker": false },
@@ -82,29 +92,12 @@
     },
     {
       "category": "Windows (x86)",
+      "footnotes": [
+        "Windows (x86) was deprecated in JDK21 and is no longer supported in newer versions: https://openjdk.org/jeps/449"
+      ],
       "distros": [
         {
           "name": "Windows Server 2022",
-          "versions": {
-            "8": { "supported": true, "docker": true },
-            "11": { "supported": true, "docker": true },
-            "17": { "supported": true, "docker": true },
-            "21": { "supported": false, "docker": false },
-            "24": { "supported": false, "docker": false }
-          }
-        },
-        {
-          "name": "Windows Server 2019",
-          "versions": {
-            "8": { "supported": true, "docker": true },
-            "11": { "supported": true, "docker": true },
-            "17": { "supported": true, "docker": true },
-            "21": { "supported": false, "docker": false },
-            "24": { "supported": false, "docker": false }
-          }
-        },
-        {
-          "name": "Windows Server 2016",
           "versions": {
             "8": { "supported": true, "docker": false },
             "11": { "supported": true, "docker": false },
@@ -114,7 +107,7 @@
           }
         },
         {
-          "name": "Windows 11",
+          "name": "Windows Server 2019",
           "versions": {
             "8": { "supported": true, "docker": false },
             "11": { "supported": true, "docker": false },
@@ -137,6 +130,9 @@
     },
     {
       "category": "Linux (x64)",
+      "footnotes": [
+        "These builds should work on any distribution with glibc version 2.17 or higher. Versions up to 17 will work with glibc 2.12."
+      ],
       "distros": [
         {
           "name": "Alpine Linux 3.5 or later (Headless)",
@@ -222,6 +218,9 @@
     },
     {
       "category": "Linux (ARM 64-bit)",
+      "footnotes": [
+        "These builds should work on any distribution with glibc version 2.17 or higher."
+      ],
       "distros": [
         {
           "name": "Alpine Linux 3.5 or later (Headless)",
@@ -297,6 +296,9 @@
     },
     {
       "category": "Linux (ARM 32-bit Hard-Float)",
+      "footnotes": [
+        "These builds should work on any distribution with glibc version 2.23 or higher."
+      ],
       "distros": [
         {
           "name": "Ubuntu 24.04",
@@ -332,6 +334,9 @@
     },
     {
       "category": "Linux (PowerPC 64-bit Little Endian)",
+      "footnotes": [
+        "These builds should work on any distribution with glibc version 2.17 or higher."
+      ],
       "distros": [
         {
           "name": "RHEL / UBI 9.x",
@@ -397,6 +402,10 @@
     },
     {
       "category": "Linux (s390x)",
+      "footnotes": [
+        "These builds should work on any distribution with glibc version 2.17 or higher.",
+        "JDK8 on s390x has no JIT so is unsupported."
+      ],
       "distros": [
         {
           "name": "RHEL / UBI 9.x",
@@ -472,6 +481,9 @@
     },
     {
       "category": "Linux (riscv64)",
+      "footnotes": [
+        "These builds should work on any distribution with glibc version 2.31 or higher."
+      ],
       "distros": [
         {
           "name": "Ubuntu 24.04",
@@ -521,7 +533,7 @@
         {
           "name": "macOS 14",
           "versions": {
-            "8": { "supported": false, "docker": false },
+            "8": { "supported": true, "docker": false },
             "11": { "supported": true, "docker": false },
             "17": { "supported": true, "docker": false },
             "21": { "supported": true, "docker": false },
@@ -556,7 +568,7 @@
         {
           "name": "macOS 15",
           "versions": {
-            "8": { "supported": true, "docker": false },
+            "8": { "supported": false, "docker": false },
             "11": { "supported": true, "docker": false },
             "17": { "supported": true, "docker": false },
             "21": { "supported": true, "docker": false },
@@ -622,6 +634,9 @@
     },
     {
       "category": "AIX (PowerPC 64-bit)",
+      "footnotes": [
+        "AIX 7.1 is no longer supported. AIX 7.2 or later is required."
+      ],
       "distros": [
         {
           "name": "AIX 7.2",

--- a/src/json/supported-platforms.schema.json
+++ b/src/json/supported-platforms.schema.json
@@ -10,6 +10,9 @@
           "category": {
             "type": "string"
           },
+          "footnotes": {
+            "type": "array"
+          },
           "distros": {
             "type": "array",
             "items": {


### PR DESCRIPTION
# Description of change

fixes: #1189 
fixes: #1089

Adds footnotes back and also removes some unsupported platforms.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/adoptium/adoptium.net/blob/main/CONTRIBUTING.md)
